### PR TITLE
Removed reference to non-existent file

### DIFF
--- a/ui.xml
+++ b/ui.xml
@@ -640,7 +640,6 @@
 	<Include file="rewards\rewards.xml"/>
 	<Include file="reputation-bar\reputation-bar.xml"/>
 
-	<Script file="rewards.lua"/>
 	<Script file="layout.lua"/>
 	<Script file="utils.lua"/>
 	<Script file="events.lua"/>


### PR DESCRIPTION
Turns out the error message about rewards.lua was from a wrong reference in a xml file. Removed it, no error about it anymore.