### PR TITLE
Multi-paragraph emotes

### DIFF
--- a/events.lua
+++ b/events.lua
@@ -474,7 +474,8 @@ local function playText(textIndex, targetModel)
 
 	Storyline_NPCFrameChatText:SetTextColor(ChatTypeInfo["MONSTER_SAY"].r, ChatTypeInfo["MONSTER_SAY"].g, ChatTypeInfo["MONSTER_SAY"].b);
 
-	if text:byte() == 60 or not UnitExists("npc") or UnitIsUnit("player", "npc") or UnitIsDead("npc") or Storyline_NPCFrameChat.stillEmote[textIndex] then -- Emote if begins with <
+	local stillEmote = Storyline_NPCFrameChat.stillEmote[textIndex];
+	if text:byte() == 60 or not UnitExists("npc") or UnitIsUnit("player", "npc") or UnitIsDead("npc") or stillEmote then -- Emote if begins with <
 		local color = colorCodeFloat(ChatTypeInfo["MONSTER_EMOTE"].r, ChatTypeInfo["MONSTER_EMOTE"].g, ChatTypeInfo["MONSTER_EMOTE"].b);
 
 		-- Blizzard is now coloring part of the text in some cases.
@@ -483,7 +484,7 @@ local function playText(textIndex, targetModel)
 		displayedText = displayedText:gsub("<", color .. "<");
 		displayedText = displayedText:gsub(">", ">|r");
 
-		if Storyline_NPCFrameChat.stillEmote[textIndex] then
+		if stillEmote then
 			displayedText = color .. displayedText;
 		end
 

--- a/events.lua
+++ b/events.lua
@@ -474,7 +474,7 @@ local function playText(textIndex, targetModel)
 
 	Storyline_NPCFrameChatText:SetTextColor(ChatTypeInfo["MONSTER_SAY"].r, ChatTypeInfo["MONSTER_SAY"].g, ChatTypeInfo["MONSTER_SAY"].b);
 
-	if text:byte() == 60 or not UnitExists("npc") or UnitIsUnit("player", "npc") or UnitIsDead("npc") then -- Emote if begins with <
+	if text:byte() == 60 or not UnitExists("npc") or UnitIsUnit("player", "npc") or UnitIsDead("npc") or Storyline_NPCFrameChat.stillEmote[textIndex] then -- Emote if begins with <
 		local color = colorCodeFloat(ChatTypeInfo["MONSTER_EMOTE"].r, ChatTypeInfo["MONSTER_EMOTE"].g, ChatTypeInfo["MONSTER_EMOTE"].b);
 
 		-- Blizzard is now coloring part of the text in some cases.
@@ -482,6 +482,10 @@ local function playText(textIndex, targetModel)
 		local displayedText = text:gsub("|r", "|r" .. color)
 		displayedText = displayedText:gsub("<", color .. "<");
 		displayedText = displayedText:gsub(">", ">|r");
+
+		if Storyline_NPCFrameChat.stillEmote[textIndex] then
+			displayedText = color .. displayedText;
+		end
 
 		Storyline_NPCFrameChatText:SetText(displayedText);
 	else

--- a/logic.lua
+++ b/logic.lua
@@ -264,19 +264,19 @@ function Storyline_API.startDialog(targetType, fullText, event, eventInfo)
 	-- Support for multi-paragraph emotes
 	local stillEmote = { false };
 	for index, text in pairs(texts) do
-		local prevEmote = stillEmote[index];
-		local currentEmote = prevEmote;
-		
-		local _, openEmoteCount = text:gsub("<", "<");
-		local _, closeEmoteCount = text:gsub(">", ">");
-
-		if prevEmote and openEmoteCount < closeEmoteCount then
-			currentEmote = false;
-		elseif not prevEmote and openEmoteCount > closeEmoteCount then
-			currentEmote = true;
-		end
-
 		if index < #texts then
+			local prevEmote = stillEmote[index];
+			local currentEmote = prevEmote;
+			
+			local _, openEmoteCount = text:gsub("<", "<");
+			local _, closeEmoteCount = text:gsub(">", ">");
+
+			if prevEmote and openEmoteCount < closeEmoteCount then
+				currentEmote = false;
+			elseif not prevEmote and openEmoteCount > closeEmoteCount then
+				currentEmote = true;
+			end
+			
 			stillEmote[index + 1] = currentEmote;
 		end
 	end

--- a/logic.lua
+++ b/logic.lua
@@ -262,24 +262,22 @@ function Storyline_API.startDialog(targetType, fullText, event, eventInfo)
 	end
 
 	-- Support for multi-paragraph emotes
-	local stillEmote = {};
+	local stillEmote = { false };
 	for index, text in pairs(texts) do
-		if index == 1 then
-			stillEmote[index] = false;
-		elseif text then
-			local prevEmote = stillEmote[index - 1];
-			local currentEmote = prevEmote;
+		local prevEmote = stillEmote[index];
+		local currentEmote = prevEmote;
+		
+		local _, openEmoteCount = text:gsub("<", "<");
+		local _, closeEmoteCount = text:gsub(">", ">");
 
-			local _, openEmoteCount = text:gsub("<", "<");
-			local _, closeEmoteCount = text:gsub(">", ">");
+		if prevEmote and openEmoteCount < closeEmoteCount then
+			currentEmote = false;
+		elseif not prevEmote and openEmoteCount > closeEmoteCount then
+			currentEmote = true;
+		end
 
-			if prevEmote and openEmoteCount < closeEmoteCount then
-				currentEmote = false;
-			elseif not prevEmote and openEmoteCount > closeEmoteCount then
-				currentEmote = true;
-			end
-
-			stillEmote[index] = currentEmote;
+		if index < #texts then
+			stillEmote[index + 1] = currentEmote;
 		end
 	end
 

--- a/logic.lua
+++ b/logic.lua
@@ -260,10 +260,34 @@ function Storyline_API.startDialog(targetType, fullText, event, eventInfo)
 	if texts[#texts]:len() == 0 then
 		texts[#texts] = nil;
 	end
+
+	-- Support for multi-paragraph emotes
+	local stillEmote = {};
+	for index, text in pairs(texts) do
+		if index == 1 then
+			stillEmote[index] = false;
+		elseif text then
+			local prevEmote = stillEmote[index - 1];
+			local currentEmote = prevEmote;
+
+			local _, openEmoteCount = text:gsub("<", "<");
+			local _, closeEmoteCount = text:gsub(">", ">");
+
+			if prevEmote and openEmoteCount < closeEmoteCount then
+				currentEmote = false;
+			elseif not prevEmote and openEmoteCount > closeEmoteCount then
+				currentEmote = true;
+			end
+
+			stillEmote[index] = currentEmote;
+		end
+	end
+
 	mainFrame.chat.texts = texts;
 	mainFrame.chat.currentIndex = 0;
 	mainFrame.chat.eventInfo = eventInfo;
 	mainFrame.chat.event = event;
+	mainFrame.chat.stillEmote = stillEmote;
 	Storyline_NPCFrameObjectivesContent:Hide();
 	mainFrame.chat.previous:Hide();
 


### PR DESCRIPTION
Some quests in Battle for Azeroth are displaying multi-paragraph emotes that aren't currently supported in Storyline (as it is only checking for a `<` at the start of the text).

What this new code does : 
- It builds a new array, `stillEmote`, of the size of the texts array. For each text index, it is true if the previous text was an emote left open, else false.

- The first index is always false, as there is no emote left open before the first text.
  - If the current text isn't continuation of an existing emote and we have more `<` than `>`, we set the next index to be a continuation of an existing emote. If we have the same number, there is either no emote or it was closed in the same paragraph, so next index isn't a continuation either.
  - If the current text is a continuation of an existing emote and we have more `>` than `<`, we set the next index to not be a continuation, as the emote is closed in the current text. If we have the same number, the emote still hasn't been closed, so next index is a continuation as well.

[Video of the code working in Boralus](https://youtu.be/mRMXE2qgPpw)

**I'll have to run through quests again to check if they ever open an emote in the middle of a text, as I don't think this behaviour is currently supported by Storyline. The multi-paragraph code would work, but I'm not 100% sure the color would be applied to the beginning of the emote.**

This code doesn't expect Blizzard to make nested emotes. I'm calling the police if they do.