### PR TITLE
Use QuestModelScene instead of QuestNPCModel

### DIFF
--- a/events.lua
+++ b/events.lua
@@ -275,7 +275,7 @@ local function showQuestPortraitFrame(isOnCompleteStep)
 
 	if questPortrait and questPortrait ~= 0 then
 		QuestFrame_ShowQuestPortrait(Storyline_NPCFrame, questPortrait, questPortraitMount, questPortraitText, questPortraitName, -16, -48);
-		QuestNPCModel:SetFrameStrata("LOW")
+		QuestModelScene:SetFrameStrata("LOW")
 	else
 		QuestFrame_HideQuestPortrait();
 	end


### PR DESCRIPTION
Seems like 8.2.5 renamed QuestNPCModel. Any quest with a model attached caused a lua error. Similar errors have been reported for Classic Quest Log