### PR TITLE
Bugfix/8.3 ptr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script: /home/travis/.luarocks/bin/luacheck . --no-color -qo "011"
 
 deploy:
   provider: script
-  script: curl -s https://raw.githubusercontent.com/BigWigsMods/packager/master/release.sh | bash -s -- -g 8.2.5 -o
+  script: curl -s https://raw.githubusercontent.com/BigWigsMods/packager/master/release.sh | bash -s -- -g 8.3.0 -o
   on:
     tags: true
 

--- a/BackgroundsManager.lua
+++ b/BackgroundsManager.lua
@@ -202,6 +202,10 @@ local SEAL_QUESTS = {
 
     [53372] = { bgAtlas = "QuestBG-Horde", text = "|cff480404"..QUEST_WARCHIEF_SYLVANAS_WINDRUNNER.."|r", sealAtlas = "Quest-Horde-WaxSeal"},
     [53370] = { bgAtlas = "QuestBG-Alliance", text = "|cff042c54"..QUEST_KING_ANDUIN_WRYNN.."|r", sealAtlas = "Quest-Alliance-WaxSeal"},
+
+    -- BfA 8.3
+    [58582] = { bgAtlas = "QuestBG-Horde", sealAtlas = "Quest-Horde-WaxSeal" },
+    [58496] = { bgAtlas = "QuestBG-Alliance", sealAtlas = "Quest-Alliance-WaxSeal"},
 };
 
 function Storyline_API.isASealedQuest(questId)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Added support for 8.3 specific campaign quests.
 - Added support for displaying War Mode bonus for quest rewards (added in the default UI with patch 8.3).
+- Added support for displaying bonus Salvaged Cache of Goods rewarded from quests replayed via the Party Sync feature.
+
+![](https://www.dropbox.com/s/oak7nnzd9zu81ps/WowT_l1ixICbyP9%20copie.png?raw=1)
 
 ## Changelog for version 3.1.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Changelog for version 3.1.4
+
+### Added
+
+- Added support for 8.3 specific campaign quests.
+- Added support for displaying War Mode bonus for quest rewards (added in the default UI with patch 8.3).
+
 ## Changelog for version 3.1.3
 
 ### Fixed

--- a/Storyline.toc
+++ b/Storyline.toc
@@ -1,4 +1,4 @@
-## Interface: 80205
+## Interface: 80300
 ## Title: Storyline
 ## Author: Ellypse and Telkostrasz
 ## Version: @project-version@

--- a/rewards/rewards.lua
+++ b/rewards/rewards.lua
@@ -41,6 +41,7 @@ local BUCKET_TYPES = {
 	FOLLOWER = 4,
 	UNLOCK = 5,
 	LEARN = 6,
+	BONUS = 7,
 	OBJECTIVES = 9,
 };
 API.BUCKET_TYPES = BUCKET_TYPES;
@@ -73,6 +74,25 @@ local MONEY_ICONS = {
 	SILVER = "Interface\\ICONS\\inv_misc_coin_03",
 	GOLD   = "Interface\\ICONS\\inv_misc_coin_01"
 }
+
+local QUEST_SESSION_BONUS_REWARD_ITEM_ID = 171305
+local item = Item:CreateFromItemID(QUEST_SESSION_BONUS_REWARD_ITEM_ID)
+local SALVAGED_CACHE_OF_GOODS = {}
+if item then
+	item:ContinueOnItemLoad(function()
+		SALVAGED_CACHE_OF_GOODS = {
+			text       = item:GetItemName(),
+			icon       = item:GetItemIcon(),
+			count      = 1,
+			index      = 1,
+			quality    = item:GetItemQuality(),
+			rewardType = "reward",
+			objectType = "questSessionBonusReward",
+			isUsable   = true,
+			itemId = QUEST_SESSION_BONUS_REWARD_ITEM_ID
+		}
+	end)
+end
 
 local REWARD_GETTERS = {
 	[BUCKET_TYPES.RECEIVED] = {
@@ -317,6 +337,19 @@ local REWARD_GETTERS = {
 
 			return auraRewards;
 		end,
+	},
+	[BUCKET_TYPES.BONUS] = {
+		[REWARD_TYPES.ITEMS] = function()
+			local rewards = {}
+
+			local questID = GetQuestID()
+			local hasChanceForQuestSessionBonusReward = C_QuestLog.QuestHasQuestSessionBonus(questID)
+			if hasChanceForQuestSessionBonusReward then
+				tinsert(rewards, SALVAGED_CACHE_OF_GOODS)
+			end
+
+			return rewards
+		end
 	}
 }
 

--- a/rewards/rewards.lua
+++ b/rewards/rewards.lua
@@ -59,6 +59,7 @@ local REWARD_TYPES = {
 	ITEMS = 6,
 	SPELL = 7,
 	FOLLOWER = 8,
+	BONUS = 9,
 }
 API.REWARD_TYPES = REWARD_TYPES;
 
@@ -186,7 +187,15 @@ local REWARD_GETTERS = {
 				});
 			end
 			return rewards;
-		end
+		end,
+		[REWARD_TYPES.BONUS] = function()
+			local questID = GetQuestID()
+			if C_QuestLog.QuestHasWarModeBonus(questID) and C_PvP.IsWarModeDesired() then
+				return { {
+					bonus = C_PvP.GetWarModeRewardBonus()
+				} }
+			end
+		end,
 	},
 	[BUCKET_TYPES.CHOICE] = {
 		[REWARD_TYPES.ITEMS] = function()

--- a/rewards/rewards.lua
+++ b/rewards/rewards.lua
@@ -189,12 +189,14 @@ local REWARD_GETTERS = {
 			return rewards;
 		end,
 		[REWARD_TYPES.BONUS] = function()
+			local rewards = {}
 			local questID = GetQuestID()
 			if C_QuestLog.QuestHasWarModeBonus(questID) and C_PvP.IsWarModeDesired() then
-				return { {
+				tinsert(rewards, {
 					bonus = C_PvP.GetWarModeRewardBonus()
-				} }
+				})
 			end
+			return rewards
 		end,
 	},
 	[BUCKET_TYPES.CHOICE] = {

--- a/rewards/rewards_buttons.lua
+++ b/rewards/rewards_buttons.lua
@@ -35,7 +35,7 @@ Storyline_API.rewards.buttons = {};
 local API = Storyline_API.rewards.buttons;
 local Rewards = Storyline_API.rewards;
 
-local function decorateItemButton(button, index, type, texture, name, numItems, isUsable, quality)
+local function decorateItemButton(button, index, type, texture, name, numItems, isUsable, quality, itemId)
 	numItems = numItems or 0;
 	button.index = index;
 	button.type = type;
@@ -49,7 +49,11 @@ local function decorateItemButton(button, index, type, texture, name, numItems, 
 	end
 	button:SetScript("OnEnter", function(self)
 		GameTooltip:SetOwner(self, "ANCHOR_RIGHT");
-		GameTooltip:SetQuestItem(self.type, self.index);
+		if itemId then
+			GameTooltip:SetItemByID(itemId)
+		else
+			GameTooltip:SetQuestItem(self.type, self.index);
+		end
 		GameTooltip_ShowCompareItem(GameTooltip);
 	end);
 	button:SetScript("OnClick", function(self)
@@ -132,7 +136,7 @@ local function decorateRewardButton(button, rewardType, reward)
 	elseif rewardType == Rewards.REWARD_TYPES.SPELL then
 		decorateSpellButton(button, reward.icon, reward.text, reward.rewardSpellIndex);
 	elseif rewardType == Rewards.REWARD_TYPES.ITEMS then
-		decorateItemButton(button, reward.index, reward.rewardType, reward.icon, reward.text, reward.count, reward.isUsable, reward.quality);
+		decorateItemButton(button, reward.index, reward.rewardType, reward.icon, reward.text, reward.count, reward.isUsable, reward.quality, reward.itemId);
 	elseif rewardType == Rewards.REWARD_TYPES.FOLLOWER then
 		decorateFollowerButton(button, reward.garrFollowerID);
 	elseif rewardType == Rewards.REWARD_TYPES.SKILL_POINTS then
@@ -257,6 +261,7 @@ local REWARDS_HEADER_TEXT = {
 	[Rewards.BUCKET_TYPES.FOLLOWER] = REWARD_FOLLOWER,
 	[Rewards.BUCKET_TYPES.UNLOCK] = REWARD_UNLOCK,
 	[Rewards.BUCKET_TYPES.LEARN] = REWARD_ABILITY,
+	[Rewards.BUCKET_TYPES.BONUS] = QUEST_SESSION_BONUS_LOOT_REWARD_FRAME_TITLE,
 	[Rewards.BUCKET_TYPES.OBJECTIVES] = TURN_IN_ITEMS,
 };
 
@@ -289,6 +294,7 @@ local function getRewardsHeader(parent, previousText)
 	-- Anchor the header either on the previous grid button on the left if there's one, or on the previous text
 	-- given to the function (objective text, rewards title, etc.)
 	header:SetPoint("TOPLEFT", API.getPreviousElementOnTheLeft() or previousText, "BOTTOMLEFT", 0, -1 * REWARDS_HEADER_MARGIN);
+	header:SetPoint("RIGHT", parent, "RIGHT", -5, 0);
 
 	return header;
 end
@@ -297,6 +303,7 @@ function API.displayRewardsOnGrid(rewardBucketType, rewardsBucket, parent, previ
 	assert(REWARDS_HEADER_TEXT[rewardBucketType], ("No header text defined for reward bucket type %s!"):format(rewardBucketType or "NO_BUCKET_TYPE"));
 
 	-- Get a header and use the apprioriate text for this reward bucket type (rewards, choices, spells, etc.)
+	---@type FontString
 	local header = getRewardsHeader(parent, previousText);
 	header:SetText(REWARDS_HEADER_TEXT[rewardBucketType]);
 	header:Show();
@@ -330,7 +337,7 @@ function API.displayRewardsOnGrid(rewardBucketType, rewardsBucket, parent, previ
 		end
 	end
 
-	return gridHeight + header:GetHeight() + REWARDS_HEADER_MARGIN;
+	return gridHeight + header:GetStringHeight() + REWARDS_HEADER_MARGIN;
 end
 
 function API.refreshButtons()

--- a/rewards/rewards_buttons.lua
+++ b/rewards/rewards_buttons.lua
@@ -103,6 +103,11 @@ local function decorateSkillPointButton(button, texture, name, skillPoints)
 	button.Name:SetWidth(81);
 end
 
+---@param button Button This will be a LargeItemButtonTemplate, WarModeBonusFrameTemplate
+local function decorateBonusButton(button, bonusAmount)
+	button.Count:SetFormattedText(PLUS_PERCENT_FORMAT, bonusAmount)
+end
+
 local function decorateSpellButton(button, texture, name, rewardSpellIndex)
 	button.Icon:SetTexture(texture);
 	button.Name:SetText(name);
@@ -132,6 +137,8 @@ local function decorateRewardButton(button, rewardType, reward)
 		decorateFollowerButton(button, reward.garrFollowerID);
 	elseif rewardType == Rewards.REWARD_TYPES.SKILL_POINTS then
 		decorateSkillPointButton(button, reward.icon, reward.text, reward.skillPoints);
+	elseif rewardType == Rewards.REWARD_TYPES.BONUS then
+		decorateBonusButton(button, reward.bonus)
 	else
 		decorateStandardButton(button, reward.icon, reward.text, reward.tooltipTitle, reward.tooltipSub);
 	end
@@ -195,6 +202,7 @@ local REWARD_BUTTON_FRAME_TEMPLATES = {
 	[Rewards.REWARD_TYPES.SPELL] = "QuestSpellTemplate, QuestInfoRewardSpellCodeTemplate",
 	[Rewards.REWARD_TYPES.SKILL_POINTS] = "Storyline_SkillPointsRewardTemplate",
 	[Rewards.REWARD_TYPES.FOLLOWER] = "Storyline_GarrisonFollowerRewardTemplate",
+	[Rewards.REWARD_TYPES.BONUS] = "LargeItemButtonTemplate, WarModeBonusFrameTemplate",
 }
 -- List of large button types, so we know to only place one of them per line instead of two (titles, followers)
 local LARGE_BUTTONS = {
@@ -229,7 +237,6 @@ local function getRewardButton(parentFrame, rewardType)
 	end
 	button.hasItem = false;
 	button:SetParent(parentFrame);
-	-- TODO Do not show the button immediately for animations ? Remplace IsShown() up there by .available
 	button:Show();
 	return button;
 end


### PR DESCRIPTION
- Added support for 8.3 specific campaign quests.
- Added support for displaying War Mode bonus for quest rewards (added in the default UI with patch 8.3).
- Added support for displaying bonus Salvaged Cache of Goods rewarded from quests replayed via the Party Sync feature.

![](https://www.dropbox.com/s/oak7nnzd9zu81ps/WowT_l1ixICbyP9%20copie.png?raw=1)