### PR TITLE
Fix for weekly reputation quests

### DIFF
--- a/BackgroundsManager.lua
+++ b/BackgroundsManager.lua
@@ -305,7 +305,25 @@ local STATIC_BACKGROUNDS = {
     --region Shadowlands
     ["1533"] = "CovenantChoice-Offering-Preview-Frame-Background-Kyrian",
     ["1569"] = "CovenantChoice-Offering-Preview-Frame-Background-Kyrian",
-    ["1813"] = "CovenantChoice-Offering-Preview-Frame-Background-Kyrian"
+    ["1813"] = "CovenantChoice-Offering-Preview-Frame-Background-Kyrian",
+
+    ["1536"] = "CovenantChoice-Offering-Preview-Frame-Background-Necrolord",
+    ["1689"] = "CovenantChoice-Offering-Preview-Frame-Background-Necrolord",
+    ["1741"] = "CovenantChoice-Offering-Preview-Frame-Background-Necrolord",
+    ["1814"] = "CovenantChoice-Offering-Preview-Frame-Background-Necrolord",
+
+    ["1565"] = "CovenantChoice-Offering-Preview-Frame-Background-NightFae",
+    ["1603"] = "CovenantChoice-Offering-Preview-Frame-Background-NightFae",
+    ["1643"] = "CovenantChoice-Offering-Preview-Frame-Background-NightFae",
+    ["1709"] = "CovenantChoice-Offering-Preview-Frame-Background-NightFae",
+    ["1739"] = "CovenantChoice-Offering-Preview-Frame-Background-NightFae",
+    ["1740"] = "CovenantChoice-Offering-Preview-Frame-Background-NightFae",
+
+    ["1525"] = "CovenantChoice-Offering-Preview-Frame-Background-Venthyr",
+    ["1688"] = "CovenantChoice-Offering-Preview-Frame-Background-Venthyr",
+    ["1734"] = "CovenantChoice-Offering-Preview-Frame-Background-Venthyr",
+    ["1738"] = "CovenantChoice-Offering-Preview-Frame-Background-Venthyr",
+    ["1742"] = "CovenantChoice-Offering-Preview-Frame-Background-Venthyr",
 
     --endregion
 

--- a/BackgroundsManager.lua
+++ b/BackgroundsManager.lua
@@ -302,6 +302,13 @@ local STATIC_BACKGROUNDS = {
     ["378"] = "charactercreate-startingzone-pandaren", -- The Wandering Isle
     ["709"] = "charactercreate-startingzone-pandaren", -- The Wandering Isle (Legion)
 
+    --region Shadowlands
+    ["1533"] = "CovenantChoice-Offering-Preview-Frame-Background-Kyrian",
+    ["1569"] = "CovenantChoice-Offering-Preview-Frame-Background-Kyrian",
+    ["1813"] = "CovenantChoice-Offering-Preview-Frame-Background-Kyrian"
+
+    --endregion
+
 }
 
 -- Use the game's Map API to get a known map ID for the player, bubbling up the chain (cave level > sub-zone > zone > continent)
@@ -431,7 +438,8 @@ function StorylineBackgroundTexture:RefreshBackground()
         -- Regular class themed backgrounds
     elseif Storyline_Data.config.dynamicBackgrounds and getCustomZoneBackground() then
         local zoneBackground = getCustomZoneBackground()
-        self.backgroundLayer:SetAtlas(zoneBackground)
+        self.backgroundLayer:SetTexCoord(0, 1, 0, 1)
+        self.backgroundLayer:SetAtlas(zoneBackground, false)
         self.dimmingLayer:SetAlpha(0.7)
         self.backgroundLayer:Show()
         self.middlegroundLayer:Hide()

--- a/BackgroundsManager.lua
+++ b/BackgroundsManager.lua
@@ -379,9 +379,18 @@ function StorylineBackgroundTexture:RefreshBackground()
     self.SealText:Hide()
 
     local questId = GetQuestID()
+    local theme = C_QuestLog.GetQuestDetailsTheme(questId);
 
     -- Special waxed seal quests
-    if SEAL_QUESTS[questId] ~= nil then
+    if theme and theme.background then
+        self.backgroundLayer:SetAtlas(theme.background);
+        self.backgroundLayer:SetTexCoord(0.2, 0.99, 0.60, 0.95)
+        self.dimmingLayer:SetAlpha(0.5)
+        self.backgroundLayer:Show()
+        self.middlegroundLayer:Hide()
+        self.foregroundLayer:Hide()
+
+    elseif SEAL_QUESTS[questId] ~= nil then
         local specialQuestDisplayInfo = SEAL_QUESTS[questId];
         self.backgroundLayer:SetAtlas(specialQuestDisplayInfo.bgAtlas);
         self.backgroundLayer:SetTexCoord(0.2, 0.99, 0.5, 0.95)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,45 +4,11 @@
 
 - Added support for Shadowlands campaign quests background (same as the regular quest frame, with a Covenant glyph).
 - Added support for showing campaign quests symbol in quest selection buttons.
-- Added background for Bastion (the others will come later).
+- Added background for the Shadowlands zones.
 - Gossip dialog choices (anything that isn't quests) are now shown at the start of the dialog, to allow bypassing long gossip paragraphs.
-- Added manual scaling for a bunch of early Shadowlands models (The Maw, Oribos, Bastion).
+- Added manual scaling for a bunch of Shadowlands common models so they can at least fit inside the Storyline frame. More models will come as I replay all the quests.
 
 ### Fixed
 
+- Fixed an issue with reputation quest reward choices being shown as invalid item (Cartel dungeon quests).
 - Restored the possibility to alt-click and control-click on models to change their offset horizontally and vertically.
-
-## Changelog for version 3.2.4
-
-### Fixed
-
-- Storyline will no longer intercept the Torghast level selection dialog.
-
-## Changelog for version 3.2.3
-
-### Fixed
-
-- Fixed a missing Blizzard template Lua error causing the settings button to not be visible.
-
-## Changelog for version 3.2.2
-
-### Fixed
-
-- Fixed missing chat bubble texture introduce in patch 9.0.2.
-
-## Changelog for version 3.2.1
-
-### Added
-
-- Added more backgrounds for the various races starting zones (thanks to keyboardturner for providing the data <3)
-
-## Changelog for version 3.2
-
-### Fixed
-
-- Fixed Lua errors caused by changes in the game's API introduced in patch 9.0.1.
-
-### Added
-
-- Added custom background of Exile's Reach.
-- Added the Shadowform special effect to your character if you have the corresponding buff on yourself.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Changelog for version 3.2.5.1
+
+### Fixed
+
+- Fixed C_CurrencyInfo.GetCurrencyContainerInfo Lua error introduced in the previous version.
+
 ## Changelog for version 3.2.5
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## Changelog for version 3.2.5
+
+### Added
+
+- Added support for Shadowlands campaign quests background (same as the regular quest frame, with a Covenant glyph).
+- Added support for showing campaign quests symbol in quest selection buttons.
+- Added background for Bastion (the others will come later).
+- Gossip dialog choices (anything that isn't quests) are now shown at the start of the dialog, to allow bypassing long gossip paragraphs.
+- Added manual scaling for a bunch of early Shadowlands models (The Maw, Oribos, Bastion).
+
+### Fixed
+
+- Restored the possibility to alt-click and control-click on models to change their offset horizontally and vertically.
+
 ## Changelog for version 3.2.4
 
 ### Fixed

--- a/debug.xml
+++ b/debug.xml
@@ -254,7 +254,7 @@
 			</Button>
 
 			<Frame parentKey="dump" inherits="Storyline_TextArea">
-				<Size x="140" y="100"/>
+				<Size x="280" y="200"/>
 				<Anchors>
 					<Anchor point="BOTTOMLEFT" relativePoint="BOTTOMRIGHT" x="10" y="10"/>
 				</Anchors>

--- a/debug.xml
+++ b/debug.xml
@@ -19,18 +19,7 @@
 		limitations under the License.
 	-->
 
-	<Frame name="Storyline_NPCFrameDebug" parentKey="debug" parent="Storyline_NPCFrame" hidden="false">
-		<Backdrop bgFile="Interface\DialogFrame\UI-DialogBox-Background" edgeFile="Interface\Tooltips\UI-Tooltip-Border" tile="true">
-			<EdgeSize>
-				<AbsValue val="16"/>
-			</EdgeSize>
-			<TileSize>
-				<AbsValue val="16"/>
-			</TileSize>
-			<BackgroundInsets>
-				<AbsInset left="5" right="5" top="5" bottom="5"/>
-			</BackgroundInsets>
-		</Backdrop>
+	<Frame name="Storyline_NPCFrameDebug" parentKey="debug" parent="Storyline_NPCFrame" hidden="false" inherits="TooltipBackdropTemplate">
 		<Size x="0" y="160"/>
 		<Anchors>
 			<Anchor point="TOPRIGHT" relativeTo="Storyline_NPCFrame" relativePoint="BOTTOMRIGHT" x="0" y="10"/>
@@ -259,9 +248,14 @@
 					<Anchor point="BOTTOMLEFT" relativePoint="BOTTOMRIGHT" x="10" y="10"/>
 				</Anchors>
 				<Frames>
-					<Button parentKey="dump" inherits="Storyline_CommonButton" text="Dump">
+					<Button parentKey="dump" inherits="Storyline_CommonButton" text="Dump target">
 						<Anchors>
 							<Anchor point="BOTTOMLEFT" relativePoint="TOPLEFT" x="0" y="10"/>
+						</Anchors>
+					</Button>
+					<Button parentKey="dumpMe" inherits="Storyline_CommonButton" text="Dump player">
+						<Anchors>
+							<Anchor point="BOTTOMLEFT" relativePoint="BOTTOMRIGHT" relativeKey="$parent.dump"/>
 						</Anchors>
 					</Button>
 				</Frames>

--- a/dialogs/dialogs.lua
+++ b/dialogs/dialogs.lua
@@ -61,7 +61,9 @@ local function getGossipAvailableQuestsChoices()
 			frequency    = questInfo.frequency,
 			isRepeatable = questInfo.repeatable,
 			isLegendary  = questInfo.isLegendary,
-			isIgnored    = questInfo.isIgnored
+			isIgnored    = questInfo.isIgnored,
+			isCampaign = QuestUtil.ShouldQuestIconsUseCampaignAppearance(questInfo.questID),
+			isCalling = C_QuestLog.IsQuestCalling(questInfo.questID)
 		};
 	end
 	return availableQuestsChoices;
@@ -79,7 +81,9 @@ local function getGossipActiveQuestsChoices()
 			isTrivial    = questInfo.isTrivial,
 			isCompleted  = questInfo.isComplete,
 			isLegendary  = questInfo.isLegendary,
-			isIgnored    = questInfo.isIgnored
+			isIgnored    = questInfo.isIgnored,
+			isCampaign = QuestUtil.ShouldQuestIconsUseCampaignAppearance(questInfo.questID),
+			isCalling = C_QuestLog.IsQuestCalling(questInfo.questID)
 		};
 		-- Place the choice in the appropriate bucket
 		if  questData.isCompleted then
@@ -99,14 +103,15 @@ local function getAvailableQuestsChoices()
 
 	for i = 1, numberOfAvailableQuests do
 		local title = GetAvailableTitle(i);
-		local isTrivial, frequency, isRepeatable, isLegendary, isIgnored = GetAvailableQuestInfo(i);
+		local isTrivial, frequency, isRepeatable, isLegendary, questID = GetAvailableQuestInfo(i);
 		availableQuestsChoices[i] = {
 			title        = title,
 			isTrivial    = isTrivial,
 			frequency    = frequency,
 			isRepeatable = isRepeatable,
 			isLegendary  = isLegendary,
-			isIgnored    = isIgnored
+			isCampaign = QuestUtil.ShouldQuestIconsUseCampaignAppearance(questID),
+			isCalling = C_QuestLog.IsQuestCalling(questID)
 		};
 	end
 	return availableQuestsChoices;
@@ -123,12 +128,15 @@ local function getActiveQuestsChoices()
 	for i = 1, numberOfActiveQuests do
 		local title, isComplete = GetActiveTitle(i);
 		local isTrivial, frequency, isRepeatable, isLegendary = GetAvailableQuestInfo(i);
+		local activeQuestID = GetActiveQuestID(i);
 		local questData = {
 			title        = title,
 			isTrivial    = isTrivial,
 			isCompleted  = isComplete,
 			isRepeatable = isRepeatable,
-			isIgnored    = isLegendary
+			isIgnored    = isLegendary,
+			isCampaign = QuestUtil.ShouldQuestIconsUseCampaignAppearance(activeQuestID),
+			isCalling = C_QuestLog.IsQuestCalling(activeQuestID)
 		};
 		-- Place the choice in the appropriate bucket
 		if  questData.isCompleted then

--- a/dialogs/dialogs_buttons.lua
+++ b/dialogs/dialogs_buttons.lua
@@ -71,8 +71,8 @@ local AVAILABLE_QUEST_ICONS_TEXTURE_PATHS = {
 	DAILY     = [[Interface\GossipFrame\DailyQuestIcon]]
 }
 
-local function getIconTextureForAvailableQuestType(frequency, isRepeatable, isLegendary)
-	return QuestUtil.GetQuestIconOffer(isLegendary, frequency, isRepeatable, isLegendary, false)
+local function getIconTextureForAvailableQuestType(frequency, isRepeatable, isLegendary, isCampaign, isCalling)
+	return QuestUtil.GetQuestIconOffer(isLegendary, frequency, isRepeatable, isCampaign, isCalling)
 end
 
 local ACTIVE_QUEST_ICONS_TEXTURE_PATHS = {
@@ -81,18 +81,18 @@ local ACTIVE_QUEST_ICONS_TEXTURE_PATHS = {
 	DAILY     = [[Interface\GossipFrame\DailyActiveQuestIcon]]
 }
 
-local function getIconTextureForActiveQuestType(frequency, isRepeatable, isLegendary)
-	return QuestUtil.GetQuestIconActive(true, isLegendary, frequency, isRepeatable, false, false)
+local function getIconTextureForActiveQuestType(frequency, isRepeatable, isLegendary, isCampaign, isCalling)
+	return QuestUtil.GetQuestIconActive(true, isLegendary, frequency, isRepeatable, isCampaign, isCalling)
 end
 
 local BUTTON_DECORATORS = {
 	[Dialogs.BUCKET_TYPE.COMPLETED_QUEST] = function(button, data)
 		button:SetText(data.title);
-		button:SetIcon(getIconTextureForActiveQuestType(data.frequency, data.isRepeatable, data.isLegendary));
+		QuestUtil.ApplyQuestIconActiveToTexture(button.icon, true, data.isLegendary, data.frequency, data.isRepeatable, data.isCampaign, data.isCovenantCalling)
 	end,
 	[Dialogs.BUCKET_TYPE.AVAILABLE_QUEST] = function(button, data)
 		button:SetText(data.title);
-		button:SetIcon(getIconTextureForAvailableQuestType(data.frequency, data.isRepeatable, data.isLegendary));
+		QuestUtil.ApplyQuestIconOfferToTexture(button.icon, data.isLegendary, data.frequency, data.isRepeatable, data.isCampaign, data.isCovenantCalling);
 		if data.isTrivial then
 			button:GreyOutIcon();
 		end
@@ -103,7 +103,7 @@ local BUTTON_DECORATORS = {
 	end,
 	[Dialogs.BUCKET_TYPE.UNCOMPLETED_QUEST] = function(button, data)
 		button:SetText(data.title);
-		button:SetIcon("Interface\\GossipFrame\\IncompleteQuestIcon");
+		QuestUtil.ApplyQuestIconActiveToTexture(button.icon, false, data.isLegendary, data.frequency, data.isRepeatable, data.isCampaign, data.isCovenantCalling)
 	end
 }
 

--- a/events.lua
+++ b/events.lua
@@ -476,7 +476,7 @@ local function handleEventSpecifics(event, texts, textIndex, eventInfo)
 
 	showQuestPortraitFrame(event == "QUEST_COMPLETE");
 
-	if textIndex == #texts and eventHandlers[event] then
+	if event == "GOSSIP_SHOW" or (textIndex == #texts and eventHandlers[event]) then
 		currentEvent = event;
 		eventHandlers[event](eventInfo);
 	end

--- a/lib/lib.xml
+++ b/lib/lib.xml
@@ -329,18 +329,7 @@
 	</Frame>
 
 	<!-- Text area -->
-	<Frame name="Storyline_TextArea" virtual="true" enableMouse="true">
-		<Backdrop edgeFile="Interface\GLUES\COMMON\TextPanel-Border" bgFile="Interface\DialogFrame\UI-DialogBox-Background" tile="true">
-			<EdgeSize>
-				<AbsValue val="20"/>
-			</EdgeSize>
-			<TileSize>
-				<AbsValue val="200"/>
-			</TileSize>
-			<BackgroundInsets>
-				<AbsInset left="5" right="5" top="5" bottom="5"/>
-			</BackgroundInsets>
-		</Backdrop>
+	<Frame name="Storyline_TextArea" virtual="true" enableMouse="true" inherits="TooltipBackdropTemplate">
 		<Frames>
 			<ScrollFrame parentKey="scroll" name="$parentScroll" inherits="UIPanelScrollFrameTemplate">
 				<Anchors>

--- a/logic.lua
+++ b/logic.lua
@@ -397,25 +397,37 @@ local function debugInit()
 	end
 
 	mainFrame.debug.dump.dump:SetScript("OnClick", function()
-		local info =
-[[["%s~%s"] = {
-  ["me"] = {
-    ["scale"] = %s,
-    ["feet"] = %s,
-    ["offset"] = %s,
-    ["facing"] = %s,
-  },
-  ["you"] = {
-    ["scale"] = %s,
-    ["feet"] = %s,
-    ["offset"] = %s,
-    ["facing"] = %s,
-	}
-},]]
+--		local info =
+--[[["%s~%s"] = {
+--  ["me"] = {
+--    ["scale"] = %s,
+--    ["feet"] = %s,
+--    ["offset"] = %s,
+--    ["facing"] = %s,
+--  },
+--  ["you"] = {
+--    ["scale"] = %s,
+--    ["feet"] = %s,
+--    ["offset"] = %s,
+--    ["facing"] = %s,
+--	}
+--},]]
+--		local formatted = info:format(
+--			playerModel:GetModelFileIDAsString(),
+--			targetModel:GetModelFileIDAsString(),
+--			mainFrame.models.me.scale, mainFrame.models.me.feet, mainFrame.models.me.offset, mainFrame.models.me.facing,
+--			mainFrame.models.you.scale, mainFrame.models.you.feet, mainFrame.models.you.offset, mainFrame.models.you.facing
+--		);
+		local info = [[
+["%s"] = {
+["scale"] = %s,
+["feet"] = %s,
+["offset"] = %s,
+["facing"] = %s,
+},
+]]
 		local formatted = info:format(
-			playerModel:GetModelFileIDAsString(),
 			targetModel:GetModelFileIDAsString(),
-			mainFrame.models.me.scale, mainFrame.models.me.feet, mainFrame.models.me.offset, mainFrame.models.me.facing,
 			mainFrame.models.you.scale, mainFrame.models.you.feet, mainFrame.models.you.offset, mainFrame.models.you.facing
 		);
 		mainFrame.debug.dump.scroll.text:SetText(formatted);

--- a/logic.lua
+++ b/logic.lua
@@ -397,38 +397,30 @@ local function debugInit()
 	end
 
 	mainFrame.debug.dump.dump:SetScript("OnClick", function()
---		local info =
---[[["%s~%s"] = {
---  ["me"] = {
---    ["scale"] = %s,
---    ["feet"] = %s,
---    ["offset"] = %s,
---    ["facing"] = %s,
---  },
---  ["you"] = {
---    ["scale"] = %s,
---    ["feet"] = %s,
---    ["offset"] = %s,
---    ["facing"] = %s,
---	}
---},]]
---		local formatted = info:format(
---			playerModel:GetModelFileIDAsString(),
---			targetModel:GetModelFileIDAsString(),
---			mainFrame.models.me.scale, mainFrame.models.me.feet, mainFrame.models.me.offset, mainFrame.models.me.facing,
---			mainFrame.models.you.scale, mainFrame.models.you.feet, mainFrame.models.you.offset, mainFrame.models.you.facing
---		);
 		local info = [[
 ["%s"] = {
 ["scale"] = %s,
 ["feet"] = %s,
 ["offset"] = %s,
 ["facing"] = %s,
-},
-]]
+},]]
 		local formatted = info:format(
 			targetModel:GetModelFileIDAsString(),
 			mainFrame.models.you.scale, mainFrame.models.you.feet, mainFrame.models.you.offset, mainFrame.models.you.facing
+		);
+		mainFrame.debug.dump.scroll.text:SetText(formatted);
+	end);
+	mainFrame.debug.dump.dumpMe:SetScript("OnClick", function()
+		local info = [[
+["%s"] = {
+["scale"] = %s,
+["feet"] = %s,
+["offset"] = %s,
+["facing"] = %s,
+},]]
+		local formatted = info:format(
+			playerModel:GetModelFileIDAsString(),
+			mainFrame.models.me.scale, mainFrame.models.me.feet, mainFrame.models.me.offset, mainFrame.models.me.facing
 		);
 		mainFrame.debug.dump.scroll.text:SetText(formatted);
 	end);
@@ -529,6 +521,9 @@ function Storyline_API.addon:OnEnable()
 		["139522"]  = true, -- Scouting map Alliance
 		["143968"]  = true, -- Island expeditions map Alliance
 		["143967"]  = true, -- Island expeditions map Port of Zandalar, Zuldazar
+
+		-- Shadowlands
+		["172400"] = true, -- Night fae mission table
 	}
 
 	C_GossipInfo.ForceGossip = function()

--- a/logic.lua
+++ b/logic.lua
@@ -231,19 +231,6 @@ function Storyline_API.startDialog(targetType, fullText, event, eventInfo)
 
 	if eventInfo.titleGetter and eventInfo.titleGetter() and eventInfo.titleGetter():len() > 0 then
 		mainFrame.Banner:Show();
-
-		if C_CampaignInfo.IsCampaignQuest(questId) then
-			local faction = UnitFactionGroup("player");
-			if faction == "Horde" then
-				mainFrame.Banner.FactionIcon:SetAtlas("bfa-landingbutton-horde-up")
-			else
-				mainFrame.Banner.FactionIcon:SetAtlas("bfa-landingbutton-alliance-up")
-			end
-			mainFrame.Banner.FactionIcon:Show()
-		else
-			mainFrame.Banner.FactionIcon:Hide()
-		end
-
 		mainFrame.Banner.Title:SetText(eventInfo.titleGetter());
 		if eventInfo.getTitleColor and eventInfo.getTitleColor() then
 			mainFrame.Banner.Title:SetTextColor(eventInfo.getTitleColor());
@@ -251,7 +238,6 @@ function Storyline_API.startDialog(targetType, fullText, event, eventInfo)
 			mainFrame.Banner.Title:SetTextColor(0.95, 0.95, 0.95);
 		end
 	else
-		mainFrame.Banner.FactionIcon:Hide()
 		mainFrame.Banner:Hide();
 	end
 

--- a/rewards/rewards.lua
+++ b/rewards/rewards.lua
@@ -253,19 +253,21 @@ local REWARD_GETTERS = {
 			-- If there is only one choice, we already dealt with it in the getItemsReward() function
 			if numberOfItemChoices == 1 then return choices end
 			for i = 1, numberOfItemChoices do
-				local _name, _texture, _amount, _quality = GetQuestCurrencyInfo("choice", i);
-				local currencyID = GetQuestCurrencyID("choice", i);
-				local name, texture, amount, quality = CurrencyContainerUtil.GetCurrencyContainerInfo(currencyID, _amount, _name, _texture, _quality);
-				tinsert(choices, {
-					text  = name,
-					icon  = texture,
-					count = amount,
-					index = i,
-					type  = "currency",
-					quality = quality,
-					currencyID = currencyID
-				});
-
+				local lootType = GetQuestItemInfoLootType("choice", i);
+				if (lootType == 1) then -- LOOT_LIST_CURRENCY
+					local _name, _texture, _amount, _quality = GetQuestCurrencyInfo("choice", i);
+					local currencyID = GetQuestCurrencyID("choice", i);
+					local name, texture, amount, quality = CurrencyContainerUtil.GetCurrencyContainerInfo(currencyID, _amount, _name, _texture, _quality);
+					tinsert(choices, {
+						text  = name,
+						icon  = texture,
+						count = amount,
+						index = i,
+						type  = "currency",
+						quality = quality,
+						currencyID = currencyID
+					});
+				end
 			end
 			return choices;
 		end,

--- a/rewards/rewards.lua
+++ b/rewards/rewards.lua
@@ -156,6 +156,7 @@ local REWARD_GETTERS = {
 						count = numItems,
 						index = i,
 						type  = "currency",
+						rewardType = "reward",
 						quality = quality,
 						currencyID = currencyID
 					});
@@ -264,6 +265,7 @@ local REWARD_GETTERS = {
 						count = amount,
 						index = i,
 						type  = "currency",
+						rewardType = "choice",
 						quality = quality,
 						currencyID = currencyID
 					});

--- a/rewards/rewards.lua
+++ b/rewards/rewards.lua
@@ -230,19 +230,45 @@ local REWARD_GETTERS = {
 			-- If there is only one choice, we already dealt with it in the getItemsReward() function
 			if numberOfItemChoices == 1 then return choices end
 			for i = 1, numberOfItemChoices do
-				local name, texture, numItems, quality, isUsable = GetQuestItemInfo("choice", i);
-				tinsert(choices, {
-					text       = name,
-					icon       = texture,
-					count      = numItems,
-					quality    = quality,
-					index      = i,
-					rewardType = "choice",
-					isUsable   = isUsable,
-				});
+				local lootType = GetQuestItemInfoLootType("choice", i);
+				if (lootType == 0) then -- LOOT_LIST_ITEM
+					local name, texture, numItems, quality, isUsable = GetQuestItemInfo("choice", i);
+					tinsert(choices, {
+						text       = name,
+						icon       = texture,
+						count      = numItems,
+						quality    = quality,
+						index      = i,
+						rewardType = "choice",
+						isUsable   = isUsable
+					})
+				end
+
 			end
 			return choices;
-		end
+		end,
+		[REWARD_TYPES.CURRENCY] = function()
+			local choices = {};
+			local numberOfItemChoices = GetNumQuestChoices();
+			-- If there is only one choice, we already dealt with it in the getItemsReward() function
+			if numberOfItemChoices == 1 then return choices end
+			for i = 1, numberOfItemChoices do
+				local _name, _texture, _amount, _quality = GetQuestCurrencyInfo("choice", i);
+				local currencyID = GetQuestCurrencyID("choice", i);
+				local name, texture, amount, quality = CurrencyContainerUtil.GetCurrencyContainerInfo(currencyID, _amount, _name, _texture, _quality);
+				tinsert(choices, {
+					text  = name,
+					icon  = texture,
+					count = amount,
+					index = i,
+					type  = "currency",
+					quality = quality,
+					currencyID = currencyID
+				});
+
+			end
+			return choices;
+		end,
 	},
 	[BUCKET_TYPES.AURA] = {
 		[REWARD_TYPES.SPELL] = function()

--- a/rewards/rewards_buttons.lua
+++ b/rewards/rewards_buttons.lua
@@ -327,12 +327,16 @@ function API.displayRewardsOnGrid(rewardBucketType, rewardsBucket, parent, previ
 			-- we set it's OnClick script
 			if rewardBucketType == Rewards.BUCKET_TYPES.CHOICE and bindClickingOnChoosingReward then
 				button:SetScript("OnClick", function(self)
-					local itemLink = GetQuestItemLink(self.type, self.index);
-					if not HandleModifiedItemClick(itemLink) and self.type == "choice" then
-						GetQuestReward(self.index);
-						Storyline_API.autoEquip(itemLink);
-						Storyline_API.autoEquipAllReward();
+					local itemLink;
+					if rewardType == Rewards.REWARD_TYPES.ITEMS then
+						itemLink = GetQuestItemLink(self.type, self.index);
+						if HandleModifiedItemClick(itemLink) or not self.type == "choice" then
+							return
+						end
 					end
+					GetQuestReward(self.index);
+					Storyline_API.autoEquip(itemLink);
+					Storyline_API.autoEquipAllReward();
 				end);
 			end
 			previousAnchor = button;

--- a/rewards/rewards_buttons.lua
+++ b/rewards/rewards_buttons.lua
@@ -132,7 +132,7 @@ end
 
 local function decorateRewardButton(button, rewardType, reward)
 	if rewardType == Rewards.REWARD_TYPES.CURRENCY then
-		decorateCurrencyButton(button, reward.index, Storyline_API.getCurrentEvent() == "QUEST_PROGRESS" and "required" or "reward", reward.icon, reward.text, reward.count, reward.currencyID, reward.quality);
+		decorateCurrencyButton(button, reward.index, reward.rewardType, reward.icon, reward.text, reward.count, reward.currencyID, reward.quality);
 	elseif rewardType == Rewards.REWARD_TYPES.SPELL then
 		decorateSpellButton(button, reward.icon, reward.text, reward.rewardSpellIndex);
 	elseif rewardType == Rewards.REWARD_TYPES.ITEMS then
@@ -327,16 +327,12 @@ function API.displayRewardsOnGrid(rewardBucketType, rewardsBucket, parent, previ
 			-- we set it's OnClick script
 			if rewardBucketType == Rewards.BUCKET_TYPES.CHOICE and bindClickingOnChoosingReward then
 				button:SetScript("OnClick", function(self)
-					local itemLink;
-					if rewardType == Rewards.REWARD_TYPES.ITEMS then
-						itemLink = GetQuestItemLink(self.type, self.index);
-						if HandleModifiedItemClick(itemLink) or not self.type == "choice" then
-							return
-						end
+					local itemLink = GetQuestItemLink(self.type, self.index);
+					if not (self.rewardType == Rewards.REWARD_TYPES.ITEMS and HandleModifiedItemClick(itemLink)) and self.type == "choice" then
+						GetQuestReward(self.index);
+						Storyline_API.autoEquip(itemLink);
+						Storyline_API.autoEquipAllReward();
 					end
-					GetQuestReward(self.index);
-					Storyline_API.autoEquip(itemLink);
-					Storyline_API.autoEquipAllReward();
 				end);
 			end
 			previousAnchor = button;

--- a/rewards/rewards_buttons.lua
+++ b/rewards/rewards_buttons.lua
@@ -214,6 +214,7 @@ local LARGE_BUTTONS = {
 	--[Rewards.REWARD_TYPES.FOLLOWER] = true, -- Follower buttons are really different and need an entire line
 }
 local itemButtons = {};
+local itemButtonsCount = 0;
 local function getRewardButton(parentFrame, rewardType)
 	local button;
 
@@ -230,7 +231,7 @@ local function getRewardButton(parentFrame, rewardType)
 	end
 	if not button then
 		-- Create a new button using the appropriate template
-		button = CreateFrame("Button", REWARDS_BUTTON_FRAME_NAME .. #itemButtons, nil, REWARD_BUTTON_FRAME_TEMPLATES[rewardType] or REWARD_BUTTON_FRAME_TEMPLATES.DEFAULT);
+		button = CreateFrame("Button", REWARDS_BUTTON_FRAME_NAME .. itemButtonsCount, nil, REWARD_BUTTON_FRAME_TEMPLATES[rewardType] or REWARD_BUTTON_FRAME_TEMPLATES.DEFAULT);
 		-- Save inside the button structure if it is a large button type
 		button.isLargeButton = LARGE_BUTTONS[rewardType] == true;
 		for scriptName, scriptFunction in pairs(REWARD_BUTTON_SHARED_SCRIPTS) do
@@ -238,6 +239,7 @@ local function getRewardButton(parentFrame, rewardType)
 		end
 		button.Refresh = refreshButton;
 		tinsert(itemButtons[rewardType], button);
+		itemButtonsCount = itemButtonsCount + 1;
 	end
 	button.hasItem = false;
 	button:SetParent(parentFrame);

--- a/ui.xml
+++ b/ui.xml
@@ -141,7 +141,7 @@
 					</Frame>
 					<CinematicModel name="Storyline_NPCFrameModelsMe" parentKey="me" setAllPoints="true" mixin="Storyline_PlayerModelMixin">
 						<Frames>
-							<Button parentKey="scroll" enableMouse="true">
+							<Button parentKey="scroll" enableMouse="true" frameStrata="MEDIUM">
 								<Anchors>
 									<Anchor point="TOP" x="0" y="-50"/>
 									<Anchor point="LEFT" x="75" y="0"/>
@@ -158,7 +158,7 @@
 					</CinematicModel>
 					<CinematicModel name="Storyline_NPCFrameModelsYou" parentKey="you" setAllPoints="true" mixin="Storyline_PlayerModelMixin">
 						<Frames>
-							<Button parentKey="scroll" enableMouse="true">
+							<Button parentKey="scroll" enableMouse="true" frameStrata="MEDIUM">
 								<Anchors>
 									<Anchor point="TOP" x="0" y="-50"/>
 									<Anchor point="RIGHT" x="-75" y="0"/>
@@ -173,7 +173,7 @@
 							<OnAnimFinished method="OnAnimFinished"/>
 						</Scripts>
 					</CinematicModel>
-					<Frame name="Storyline_NPCFrameGossipChoices" inherits="Storyline_HoveredFrame" hidden="true">
+					<Frame name="Storyline_NPCFrameGossipChoices" inherits="Storyline_HoveredFrame" hidden="true" frameStrata="HIGH">
 						<Size x="325" y="150"/>
 						<Layers>
 							<Layer level="OVERLAY">

--- a/ui.xml
+++ b/ui.xml
@@ -281,14 +281,6 @@
 							</Anchors>
 						</FontString>
 					</Layer>
-					<Layer level="OVERLAY" textureSubLevel="4">
-						<Texture parentKey="FactionIcon">
-							<Size x="30" y="33" />
-							<Anchors>
-								<Anchor point="RIGHT" relativePoint="LEFT" relativeKey="$parent.Title" x="0" y="-4"  />
-							</Anchors>
-						</Texture>
-					</Layer>
 				</Layers>
 			</Frame>
 

--- a/ui.xml
+++ b/ui.xml
@@ -141,7 +141,7 @@
 					</Frame>
 					<CinematicModel name="Storyline_NPCFrameModelsMe" parentKey="me" setAllPoints="true" mixin="Storyline_PlayerModelMixin">
 						<Frames>
-							<Button parentKey="scroll" enableMouse="true" frameStrata="MEDIUM">
+							<Button parentKey="scroll" enableMouse="true" frameStrata="HIGH" frameLevel="1">
 								<Anchors>
 									<Anchor point="TOP" x="0" y="-50"/>
 									<Anchor point="LEFT" x="75" y="0"/>
@@ -158,7 +158,7 @@
 					</CinematicModel>
 					<CinematicModel name="Storyline_NPCFrameModelsYou" parentKey="you" setAllPoints="true" mixin="Storyline_PlayerModelMixin">
 						<Frames>
-							<Button parentKey="scroll" enableMouse="true" frameStrata="MEDIUM">
+							<Button parentKey="scroll" enableMouse="true" frameStrata="HIGH" frameLevel="1">
 								<Anchors>
 									<Anchor point="TOP" x="0" y="-50"/>
 									<Anchor point="RIGHT" x="-75" y="0"/>
@@ -173,7 +173,7 @@
 							<OnAnimFinished method="OnAnimFinished"/>
 						</Scripts>
 					</CinematicModel>
-					<Frame name="Storyline_NPCFrameGossipChoices" inherits="Storyline_HoveredFrame" hidden="true" frameStrata="HIGH">
+					<Frame name="Storyline_NPCFrameGossipChoices" inherits="Storyline_HoveredFrame" hidden="true" frameStrata="HIGH" frameLevel="2">
 						<Size x="325" y="150"/>
 						<Layers>
 							<Layer level="OVERLAY">
@@ -284,7 +284,7 @@
 				</Layers>
 			</Frame>
 
-			<Frame name="Storyline_NPCFrameChat" parentKey="chat" frameStrata="HIGH">
+			<Frame name="Storyline_NPCFrameChat" parentKey="chat" frameStrata="HIGH" frameLevel="2">
 				<Size x="0" y="150"/>
 				<Anchors>
 					<Anchor point="BOTTOM" x="0" y="25"/>


### PR DESCRIPTION
Main focus of this PR is fixing the reputation choice for the weekly dungeon quests (and WQ event quest). I added the reward types directly to the currency reward arrays (similar to what was done in the items and currency objective ones) and am using those in the decorateCurrencyButton directly, so that currency choice buttons have a self.type == "choice" (previously was reward, which meant the test would fail).

The added condition on HandleModifiedItemClick is to avoid randomly showing the dressing room when Ctrl-clicking a currency, it'll just select it instead as if no modifier was used.

Finally, the added itemButtonsCount variable is there to fix the button names all being the same (as the array is not really 1D, the # operator didn't really count the amount of buttons already created, so I opted to keep count manually). It was only fixed because I thought it might have been part of the issue, but ended up being unrelated, but heh.